### PR TITLE
Expose actors etc. to be consumed programatically

### DIFF
--- a/src/serilog-generator/Actors/Administrator.cs
+++ b/src/serilog-generator/Actors/Administrator.cs
@@ -3,7 +3,7 @@ using Serilog.Generator.Model;
 
 namespace Serilog.Generator.Actors
 {
-    class Administrator
+    public class Administrator
     {
         readonly Catalog _catalog;
         readonly ActiveAgent _ai;

--- a/src/serilog-generator/Actors/Customer.cs
+++ b/src/serilog-generator/Actors/Customer.cs
@@ -5,7 +5,7 @@ using Serilog.Generator.Model;
 
 namespace Serilog.Generator.Actors
 {
-    class Customer : IDisposable
+    public class Customer : IDisposable
     {
         readonly Catalog _catalog;
         readonly ActiveAgent _ai;

--- a/src/serilog-generator/Actors/TrafficReferral.cs
+++ b/src/serilog-generator/Actors/TrafficReferral.cs
@@ -4,7 +4,7 @@ using Serilog.Generator.Model;
 
 namespace Serilog.Generator.Actors
 {
-    class TrafficReferral
+    public class TrafficReferral
     {
         readonly ConcurrentBag<Customer> _customers;
         readonly Catalog _catalog;

--- a/src/serilog-generator/Model/Catalog.cs
+++ b/src/serilog-generator/Model/Catalog.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Serilog.Generator.Model
 {
-    class Catalog
+    public class Catalog
     {
         readonly IList<Product> _products;
         readonly Random _random = new Random();

--- a/src/serilog-generator/Model/Product.cs
+++ b/src/serilog-generator/Model/Product.cs
@@ -1,6 +1,6 @@
 ﻿namespace Serilog.Generator.Model
 {
-    class Product
+    public class Product
     {
         public int Id { get; set; }
         public string Name { get; set; }


### PR DESCRIPTION
I had a few situations (e.g. multiple sinks in Splunk) that would be nice to programatically use the test stubs in the generator.

I can target many sinks on the command line however sometimes I want a little more control.

Other ideas welcome cc: @serilog/core 
